### PR TITLE
fix(env): 添加默认的 ENV 参数，防止用户漏加 ENV 变量(#34)

### DIFF
--- a/client_v3/src/pages/Multiplayer.jsx
+++ b/client_v3/src/pages/Multiplayer.jsx
@@ -14,7 +14,7 @@ import '../styles/game.css';
 import CryptoJS from 'crypto-js';
 import { useLocalStorage } from 'usehooks-ts';
 
-const secret = import.meta.env.VITE_AES_SECRET;
+const secret = import.meta.env.VITE_AES_SECRET || 'My-Secret-Key';
 const SOCKET_URL = import.meta.env.VITE_SERVER_URL || 'http://localhost:3000';
 
 const Multiplayer = () => {

--- a/server_v3/server.js
+++ b/server_v3/server.js
@@ -8,11 +8,13 @@ require('dotenv').config();
 const app = express();
 const server = http.createServer(app);
 const PORT = process.env.PORT || 3000;
-// const secret = "my-secret-key";
+const CLIENT_URL = process.env.CLIENT_URL || 'http://localhost:5173';
+const SERVER_URL = process.env.SERVER_URL || 'http://localhost:3000';
+
 const cors_options = {
     origin: [
-        process.env.CLIENT_URL,
-        process.env.SERVER_URL
+        CLIENT_URL,
+        SERVER_URL
     ],
       methods: ['GET', 'POST'],
       credentials: true


### PR DESCRIPTION
添加默认的 ENV 参数，防止用户漏加 ENV 变量，具体为：

const secret = import.meta.env.VITE_AES_SECRET || 'My-Secret-Key';
const CLIENT_URL = process.env.CLIENT_URL || 'http://localhost:5173';
const SERVER_URL = process.env.SERVER_URL || 'http://localhost:3000';


