### PR TITLE
Add `RoomManager` page at the `/multiplayer` endpoint

### DIFF
--- a/client_v3/src/App.jsx
+++ b/client_v3/src/App.jsx
@@ -2,6 +2,7 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Home from './pages/Home';
 import SinglePlayer from './pages/SinglePlayer';
 import Multiplayer from './pages/Multiplayer';
+import RoomManager from './pages/RoomManager';
 
 function App() {
   return (
@@ -9,7 +10,7 @@ function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/singleplayer" element={<SinglePlayer />} />
-        <Route path="/multiplayer" element={<Multiplayer />} />
+        <Route path="/multiplayer" element={<RoomManager />} />
         <Route path="/multiplayer/:roomId" element={<Multiplayer />} />
       </Routes>
     </Router>

--- a/client_v3/src/pages/Multiplayer.jsx
+++ b/client_v3/src/pages/Multiplayer.jsx
@@ -163,8 +163,15 @@ const Multiplayer = () => {
       setIsHost(true);
       navigate(`/multiplayer/${newRoomId}`);
     } else {
+      // Check if user is the creator from URL query params
+      const urlParams = new URLSearchParams(window.location.search);
+      const isCreator = urlParams.get('creator') === 'true';
+      if (isCreator) {
+        setIsHost(true);
+      }
+      
       // Set room URL for sharing
-      setRoomUrl(window.location.href);
+      setRoomUrl(window.location.href.split('?')[0]);
     }
   }, [roomId, navigate]);
 

--- a/client_v3/src/pages/RoomManager.jsx
+++ b/client_v3/src/pages/RoomManager.jsx
@@ -1,0 +1,340 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { v4 as uuidv4 } from 'uuid';
+import axios from 'axios';
+import '../styles/RoomManager.css';
+import { useLocalStorage } from 'usehooks-ts';
+
+const SOCKET_URL = import.meta.env.VITE_SERVER_URL || 'http://localhost:3000';
+
+const RoomManager = () => {
+  const navigate = useNavigate();
+  const [roomInput, setRoomInput] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
+  const [loadingRooms, setLoadingRooms] = useState(false);
+  const [copyMessage, setCopyMessage] = useState('');
+
+  // Room history stored in local storage
+  const [roomHistory, setRoomHistory] = useLocalStorage('room-history', []);
+
+  // Filter and update room history status
+  useEffect(() => {
+    const updateRoomStatuses = async () => {
+      if (roomHistory.length === 0) return;
+      
+      setLoadingRooms(true);
+      
+      try {
+        // Create a copy of room history to update
+        const updatedHistory = [...roomHistory];
+        
+        // Update each room's status if it's not too old (older than 24 hours)
+        const oneDayAgo = Date.now() - 24 * 60 * 60 * 1000;
+        
+        for (let i = 0; i < updatedHistory.length; i++) {
+          const room = updatedHistory[i];
+          
+          // Skip rooms older than 24 hours
+          if (room.lastVisited && new Date(room.lastVisited).getTime() < oneDayAgo) {
+            continue;
+          }
+          
+          try {
+            const response = await axios.get(`${SOCKET_URL}/api/rooms/${room.id}`);
+            updatedHistory[i] = {
+              ...room,
+              exists: response.data.exists,
+              isPublic: response.data.isPublic,
+              playerCount: response.data.playerCount,
+              playerNames: response.data.playerNames,
+              inGame: response.data.inGame,
+              lastChecked: Date.now()
+            };
+          } catch (error) {
+            // If room doesn't exist or error occurs
+            updatedHistory[i] = {
+              ...room,
+              exists: false,
+              lastChecked: Date.now()
+            };
+          }
+        }
+        
+        setRoomHistory(updatedHistory);
+      } catch (error) {
+        console.error('Error updating room statuses:', error);
+      } finally {
+        setLoadingRooms(false);
+      }
+    };
+    
+    updateRoomStatuses();
+  }, []);
+
+  // Handle create room
+  const handleCreateRoom = () => {
+    const newRoomId = uuidv4();
+    
+    // Add to history
+    const newRoom = {
+      id: newRoomId,
+      type: 'created',
+      createdAt: Date.now(),
+      lastVisited: Date.now(),
+      exists: true,
+    };
+    
+    setRoomHistory(prev => [newRoom, ...prev.filter(room => room.id !== newRoomId)]);
+    
+    // Navigate to the room with creator flag
+    navigate(`/multiplayer/${newRoomId}?creator=true`);
+  };
+
+  // Handle join room
+  const handleJoinRoom = () => {
+    if (!roomInput.trim()) {
+      setErrorMessage('请输入房间ID或房间链接');
+      return;
+    }
+    
+    // Extract room ID if a full URL was pasted
+    let roomId = roomInput.trim();
+    
+    if (roomId.includes('/multiplayer/')) {
+      roomId = roomId.split('/multiplayer/')[1].split(/[?#]/)[0];
+    }
+    
+    // Validate room ID format
+    if (!roomId.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i)) {
+      setErrorMessage('无效的房间ID格式');
+      return;
+    }
+    
+    // Check if room exists
+    axios.get(`${SOCKET_URL}/api/rooms/${roomId}`)
+      .then(response => {
+        if (response.data.exists) {
+          // Add to history
+          const newRoom = {
+            id: roomId,
+            type: 'joined',
+            createdAt: response.data.createdAt,
+            lastVisited: Date.now(),
+            exists: true,
+            isPublic: response.data.isPublic,
+            playerCount: response.data.playerCount,
+            playerNames: response.data.playerNames,
+            inGame: response.data.inGame,
+            lastChecked: Date.now()
+          };
+          
+          setRoomHistory(prev => [newRoom, ...prev.filter(room => room.id !== roomId)]);
+          
+          // Navigate to the room
+          navigate(`/multiplayer/${roomId}`);
+        } else {
+          setErrorMessage('房间不存在');
+        }
+      })
+      .catch(() => {
+        setErrorMessage('房间不存在或无法连接到服务器');
+      });
+  };
+
+  // Handle room item click
+  const handleRoomClick = (roomId) => {
+    // Update last visited time
+    setRoomHistory(prev => 
+      prev.map(room => 
+        room.id === roomId 
+          ? {...room, lastVisited: Date.now()} 
+          : room
+      )
+    );
+    
+    // Navigate to the room without creator flag
+    navigate(`/multiplayer/${roomId}`);
+  };
+
+  // Delete room from history
+  const handleDeleteRoom = (e, roomId) => {
+    e.stopPropagation();
+    setRoomHistory(prev => prev.filter(room => room.id !== roomId));
+  };
+
+  // Clear entire history
+  const handleClearHistory = () => {
+    if (window.confirm('确定要清空房间历史记录吗？')) {
+      setRoomHistory([]);
+    }
+  };
+
+  // Format date for display
+  const formatDate = (timestamp) => {
+    if (!timestamp) return 'N/A';
+    
+    const date = new Date(timestamp);
+    return date.toLocaleString('zh-CN', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit'
+    });
+  };
+
+  // Copy room ID to clipboard
+  const copyRoomId = (e, roomId) => {
+    e.stopPropagation();
+    navigator.clipboard.writeText(roomId)
+      .then(() => {
+        setCopyMessage('房间ID已复制到剪贴板');
+        setTimeout(() => setCopyMessage(''), 2000);
+      })
+      .catch(err => {
+        console.error('无法复制房间ID:', err);
+      });
+  };
+
+  return (
+    <div className="room-manager-container">
+      {copyMessage && (
+        <div className="copy-notification">
+          {copyMessage}
+        </div>
+      )}
+      
+      <div className="content-wrapper">
+        <div className="room-actions">
+          <div className="create-room-section">
+            <h2>创建房间</h2>
+            <p>创建一个新的游戏房间，你将成为房主并可以设置游戏参数。创建后可以邀请好友加入。</p>
+            <button 
+              className="create-room-button"
+              onClick={handleCreateRoom}
+            >
+              创建新房间
+            </button>
+          </div>
+          
+          <div className="join-room-section">
+            <h2>加入房间</h2>
+            <p>输入房间ID或房间链接加入已有的游戏。确保房间公开且游戏尚未开始。</p>
+            <div className="join-room-input-group">
+              <input
+                type="text"
+                placeholder="输入房间ID或房间链接"
+                value={roomInput}
+                onChange={(e) => {
+                  setRoomInput(e.target.value);
+                  setErrorMessage('');
+                }}
+                className="join-room-input"
+              />
+              <button 
+                className="join-room-button"
+                onClick={handleJoinRoom}
+              >
+                加入
+              </button>
+            </div>
+            {errorMessage && <p className="error-message">{errorMessage}</p>}
+          </div>
+        </div>
+        
+        <div className="room-history-section">
+          <div className="room-history-header">
+            <h2>历史房间</h2>
+            {roomHistory.length > 0 && (
+              <button 
+                className="clear-history-button"
+                onClick={handleClearHistory}
+              >
+                清空历史
+              </button>
+            )}
+          </div>
+          
+          {loadingRooms ? (
+            <div className="loading-message">正在加载房间状态...</div>
+          ) : (
+            <>
+              {roomHistory.length > 0 ? (
+                <div className="room-list">
+                  {roomHistory
+                    .sort((a, b) => (b.lastVisited || 0) - (a.lastVisited || 0))
+                    .map((room) => (
+                      <div 
+                        key={room.id} 
+                        className={`room-item ${!room.exists ? 'inactive' : ''} ${room.inGame ? 'in-game' : ''}`}
+                      >
+                        <div className="room-info">
+                          <div className="room-primary-info">
+                            <span className={`room-type-badge ${room.type === 'created' ? 'created' : 'joined'}`}>
+                              {room.type === 'created' ? '创建' : '加入'}
+                            </span>
+                            <span 
+                              className="room-id"
+                              onClick={(e) => copyRoomId(e, room.id)}
+                              title="点击复制房间ID"
+                            >
+                              <span className="room-id-label">房间ID:</span> {room.id.substring(0, 8)}... <span className="copy-icon">📋</span>
+                            </span>
+                            {room.exists && (
+                              <span className={`room-status ${room.isPublic ? 'public' : 'private'}`}>
+                                {room.isPublic ? '🔓公开' : '🔒私密'}
+                              </span>
+                            )}
+                            {room.exists && room.inGame && (
+                              <span className="room-game-status">游戏中</span>
+                            )}
+                          </div>
+                          <div className="room-secondary-info">
+                            {room.exists ? (
+                              <span className="player-count">
+                                玩家数量：{room.playerCount || 0}
+                              </span>
+                            ) : (
+                              <span className="room-not-exists">房间不存在</span>
+                            )}
+                            <span className="room-date">
+                              最近访问：{formatDate(room.lastVisited)}
+                            </span>
+                          </div>
+                        </div>
+                        <div className="room-action-buttons">
+                          {room.exists && !room.inGame && room.isPublic && (
+                            <button 
+                              className="join-room-button-small"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleRoomClick(room.id);
+                              }}
+                              title="加入房间"
+                            >
+                              加入
+                            </button>
+                          )}
+                          <button 
+                            className="delete-room-button"
+                            onClick={(e) => handleDeleteRoom(e, room.id)}
+                            title="从历史记录中删除"
+                          >
+                            删除
+                          </button>
+                        </div>
+                      </div>
+                    ))}
+                </div>
+              ) : (
+                <div className="no-history-message">暂无历史房间记录</div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RoomManager; 

--- a/client_v3/src/styles/RoomManager.css
+++ b/client_v3/src/styles/RoomManager.css
@@ -1,0 +1,408 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+/* 添加全局背景样式 */
+html, body, #root {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(135deg, #f5f7fa 0%, #e4e9f2 100%);
+}
+
+.room-manager-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-height: 100vh;
+  width: 100%;
+  padding: 1rem;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  box-sizing: border-box;
+  padding-top: 3rem;
+}
+
+.content-wrapper {
+  width: 100%;
+  max-width: 1200px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 3rem;
+}
+
+.room-actions {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 3rem;
+  width: 100%;
+  gap: 2rem;
+}
+
+.create-room-section,
+.join-room-section {
+  flex: 1;
+  background-color: white;
+  border-radius: 8px;
+  padding: 1.5rem;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+  height: 220px;
+  display: flex;
+  flex-direction: column;
+}
+
+.create-room-section h2,
+.join-room-section h2 {
+  margin-bottom: 0.5rem;
+}
+
+.create-room-section p,
+.join-room-section p {
+  color: #666;
+  font-size: 0.9rem;
+  margin-bottom: 0.8rem;
+  line-height: 1.4;
+}
+
+.room-history-section {
+  background-color: white;
+  border-radius: 8px;
+  padding: 1.5rem;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+  width: 100%;
+}
+
+h2 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  color: #333;
+  font-size: 1.5rem;
+}
+
+.create-room-button {
+  padding: 10px 20px;
+  font-size: 16px;
+  font-weight: 600;
+  background-color: #27ae60; /* 绿色 */
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  margin-top: auto;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+}
+
+.create-room-button:hover {
+  background-color: #219a52;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
+
+.join-room-input-group {
+  display: flex;
+  gap: 8px;
+  height: 46px;
+  margin-top: auto;
+}
+
+.join-room-input {
+  flex: 1;
+  height: 100%;
+  width: 100%;
+  padding: 8px 16px;
+  font-size: 16px;
+  border: 1px solid #e2e8f0;
+  border-radius: 4px;
+  background: #fff;
+  color: #1e293b;
+  box-sizing: border-box;
+}
+
+.join-room-input:focus {
+  border-color: #646cff;
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(100, 108, 255, 0.1);
+}
+
+.join-room-button {
+  padding: 10px 20px;
+  font-size: 16px;
+  font-weight: 600;
+  background-color: #4a90e2; /* 蓝色 */
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+}
+
+.join-room-button:hover {
+  background-color: #357abd;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
+
+.error-message {
+  color: #ff6b6b;
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.room-history-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.clear-history-button {
+  padding: 8px 16px;
+  font-size: 14px;
+  font-weight: 600;
+  background-color: #f39c12; /* 橙色 */
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.clear-history-button:hover {
+  background-color: #e67e22;
+  transform: translateY(-1px);
+  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.15);
+}
+
+.loading-message,
+.no-history-message {
+  text-align: center;
+  padding: 2rem;
+  color: #757575;
+  font-style: italic;
+}
+
+.room-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.room-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background-color: white;
+  border-radius: 4px;
+  padding: 1rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.room-item:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.room-item.inactive {
+  opacity: 0.7;
+  background-color: #f9f9f9;
+}
+
+.room-item.in-game {
+  border-left: 4px solid #FFC107;
+}
+
+.room-info {
+  flex: 1;
+}
+
+.room-primary-info {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  margin-bottom: 0.5rem;
+}
+
+.room-type-badge {
+  padding: 0.3rem 0.6rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  color: white;
+  background-color: #4a90e2; /* 默认蓝色 */
+}
+
+/* 我们不能使用:contains选择器，需要在JSX代码中处理颜色 */
+.room-type-badge.created {
+  background-color: #27ae60; /* 绿色 */
+}
+
+.room-type-badge.joined {
+  background-color: #4a90e2; /* 蓝色 */
+}
+
+.room-id {
+  display: inline-flex;
+  align-items: center;
+  position: relative;
+  font-family: 'Courier New', monospace;
+  font-weight: 600;
+  background-color: #f5f5f5;
+  padding: 4px 10px;
+  border-radius: 4px;
+  margin: 0 8px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.room-id:hover {
+  background-color: #e0e0e0;
+  transform: translateY(-1px);
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+}
+
+.room-id-label {
+  color: #666;
+  font-weight: normal;
+  margin-right: 4px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-size: 0.85rem;
+}
+
+.copy-icon {
+  margin-left: 4px;
+  font-size: 12px;
+  opacity: 0.7;
+}
+
+.room-id:hover .copy-icon {
+  opacity: 1;
+}
+
+.room-status {
+  font-size: 0.9rem;
+}
+
+.room-status.public {
+  color: #4CAF50;
+}
+
+.room-status.private {
+  color: #F44336;
+}
+
+.room-game-status {
+  background-color: #9b59b6; /* 紫色 */
+  color: white;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+}
+
+.room-secondary-info {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.85rem;
+  color: #757575;
+}
+
+.room-not-exists {
+  color: #F44336;
+}
+
+.room-action-buttons {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.join-room-button-small {
+  padding: 6px 12px;
+  font-size: 14px;
+  font-weight: 600;
+  background-color: #4a90e2; /* 蓝色 */
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.join-room-button-small:hover {
+  background-color: #357abd;
+  transform: translateY(-1px);
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
+}
+
+.delete-room-button {
+  padding: 5px 10px;
+  font-size: 12px;
+  font-weight: 600;
+  background-color: #ff6b6b; /* 红色 */
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.delete-room-button:hover {
+  background-color: #e45050;
+  transform: translateY(-1px);
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
+}
+
+/* Copy notification */
+.copy-notification {
+  position: fixed;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: rgba(0, 0, 0, 0.7);
+  color: white;
+  padding: 10px 16px;
+  border-radius: 4px;
+  z-index: 1000;
+  animation: fadeInOut 2s ease-in-out;
+}
+
+@keyframes fadeInOut {
+  0% { opacity: 0; }
+  15% { opacity: 1; }
+  85% { opacity: 1; }
+  100% { opacity: 0; }
+}
+
+/* Responsive styling */
+@media (max-width: 768px) {
+  .room-manager-container {
+    padding: 1rem;
+  }
+  
+  .room-actions {
+    flex-direction: column;
+  }
+  
+  .create-room-section,
+  .join-room-section {
+    width: 100%;
+    height: auto;
+  }
+  
+  .join-room-input-group {
+    flex-direction: column;
+  }
+  
+  .room-primary-info {
+    flex-wrap: wrap;
+  }
+  
+  .room-action-buttons {
+    flex-direction: column;
+  }
+} 

--- a/client_v3/src/styles/RoomManager.css
+++ b/client_v3/src/styles/RoomManager.css
@@ -213,10 +213,6 @@ h2 {
   background-color: #f9f9f9;
 }
 
-.room-item.in-game {
-  border-left: 4px solid #FFC107;
-}
-
 .room-info {
   flex: 1;
 }

--- a/server_v3/server.js
+++ b/server_v3/server.js
@@ -52,6 +52,7 @@ io.on('connection', (socket) => {
     rooms.set(roomId, {
       host: socket.id,
       isPublic: true, // Default to public
+      createdAt: Date.now(),
       players: [{
         id: socket.id,
         username,
@@ -481,6 +482,29 @@ io.on('connection', (socket) => {
 
 app.get('/ping', (req, res) => {
   res.status(200).send('Server is active');
+});
+
+// API to get room status
+app.get('/api/rooms/:roomId', (req, res) => {
+  const roomId = req.params.roomId;
+  const room = rooms.get(roomId);
+  
+  if (!room) {
+    return res.status(404).json({ 
+      exists: false,
+      message: 'Room not found' 
+    });
+  }
+  
+  // Return room status without sensitive information
+  res.json({
+    exists: true,
+    isPublic: room.isPublic,
+    playerCount: room.players.length,
+    playerNames: room.players.map(p => p.username),
+    inGame: !!room.currentGame,
+    createdAt: room.createdAt || Date.now()
+  });
 });
 
 startSelfPing();


### PR DESCRIPTION
I noticed that the browser back functionality doesn't work properly in the previous multi-player mode interface, which is due to the current room creation and joining redirection logic. Therefore, I think we should add a unified room management page endpoint.

Add `RoomManager` page at the `/multiplayer` endpoint to support room creation, joining, viewing and managing room history, and checking room status. Enhances the multiplayer experience.

![image](https://github.com/user-attachments/assets/c02bc671-7a7b-454b-b092-1db4e6951290)
