### PR TITLE
fix score-table button font color under dark mode

### DIFF
--- a/client_v3/src/styles/Multiplayer.css
+++ b/client_v3/src/styles/Multiplayer.css
@@ -430,6 +430,10 @@
     color: #1e293b;
   }
   
+  .score-table th button {
+    color: #1e293b;
+  }
+  
   .visibility-button {
     background-color: #f39c12;
     color: white;


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/d45caab0-0de9-48b8-abcd-2c376b8baf60)

After:
![image](https://github.com/user-attachments/assets/2f34cf58-8a64-451f-ac4c-bd0b0e5aa6c7)
