### PR TITLE
fix:调整了在dark mode下自定义标签的显示

### DIFF
--- a/client_v3/src/components/TagContributionPopup.jsx
+++ b/client_v3/src/components/TagContributionPopup.jsx
@@ -148,6 +148,10 @@ function TagContributionPopup({ character, onClose }) {
                       maxLength={8}
                       className={inputError ? 'has-error' : ''}
                       disabled={totalTags >= MAX_TAGS}
+                      style={{
+                        backgroundColor: '#ffffff',
+                        color: '#000000',
+                      }}
                     />
                     <button 
                       onClick={handleCustomTagAdd}


### PR DESCRIPTION
调整了在dark mode下自定义标签的显示

调整前：
![image](https://github.com/user-attachments/assets/fe378ec2-04e4-4af4-963b-e28c80216a2f)

调整后：
![image](https://github.com/user-attachments/assets/a250d2af-efe2-44e1-b5e2-3591b78e89fd)
