### PR TITLE
style(visibility-button): 修复私密按钮 hover 时为白色的情况

### DIFF
--- a/client_v3/src/styles/Multiplayer.css
+++ b/client_v3/src/styles/Multiplayer.css
@@ -457,7 +457,7 @@
 }
 
 .visibility-button:hover {
-    background-color: #f0f0f0;
+  background-color: #e67e22;
 }
 
 .fa-angle-left {


### PR DESCRIPTION
修复私密按钮鼠标 hover 时为白色的情况

前：
<img width="273" alt="Snipaste_2025-04-18_19-17-32" src="https://github.com/user-attachments/assets/5d8ac0e9-b3b5-43e5-8a77-d0dc20604cfb" />

后：
<img width="245" alt="Snipaste_2025-04-18_19-17-46" src="https://github.com/user-attachments/assets/068b29b8-970d-467a-b37d-81ec5ae450e8" />
