### PR TITLE
fix(surrender): reset button state when restarting game

### DIFF
--- a/client_v3/src/pages/SinglePlayer.jsx
+++ b/client_v3/src/pages/SinglePlayer.jsx
@@ -237,6 +237,7 @@ function SinglePlayer() {
     setCurrentTimeLimit(gameSettings.timeLimit);
     setCurrentSubjectSearch(gameSettings.subjectSearch);
     setShouldResetTimer(false);
+    setFinishInit(false);
     setHints({
       first: null,
       second: null
@@ -265,6 +266,7 @@ function SinglePlayer() {
           second: hintTexts[1]
         });
         console.log('初始化游戏', gameSettings);
+        setFinishInit(true);
       } catch (error) {
         console.error('Failed to initialize new game:', error);
         alert('游戏初始化失败，请重试');


### PR DESCRIPTION
This commit further fixes the issue reported in #33 where restarting after surrender caused problems, enhancing the solution in #53.
Fixed surrender button remaining enabled when restarting the game. Now properly disables the button during initialization for both first game load and subsequent restarts, preventing blank screen errors when clicked prematurely.
