### PR TITLE
新增预设配置功能，简化设置选项的应用，优化多人游戏界面中的游戏设置显示

### DIFF
--- a/client_v3/src/components/GameSettingsDisplay.jsx
+++ b/client_v3/src/components/GameSettingsDisplay.jsx
@@ -1,0 +1,188 @@
+import React from 'react';
+import { matchPreset } from '../data/presets';
+import '../styles/GameSettingsDisplay.css';
+/*这是多人游戏参与者视角，游戏设置的相关内容*/
+/**
+ * 游戏设置显示组件 - 将JSON格式的游戏设置转换为中文可视化显示
+ * 
+ * @param {Object} props
+ * @param {Object} props.settings - 游戏设置对象
+ * @param {string} props.title - 显示标题，默认为"该房间的题库范围"
+ * @param {boolean} props.collapsible - 是否可折叠，默认为true
+ * @param {boolean} props.defaultExpanded - 默认是否展开，默认为true
+ */
+const GameSettingsDisplay = ({ 
+  settings, 
+  title = "该房间的题库范围", 
+  collapsible = true,
+  defaultExpanded = true
+}) => {
+  const [isExpanded, setIsExpanded] = React.useState(defaultExpanded);
+
+  // 如果没有settings或settings是空对象，显示提示信息
+  if (!settings || Object.keys(settings).length === 0) {
+    return (
+      <div className="game-settings-display">
+        <div className="settings-display-header">
+          <h3>{title}</h3>
+        </div>
+        <div className="settings-display-content">
+          <div className="settings-group">
+            <div className="settings-items">
+              <div className="settings-item">
+                <span className="setting-value">加载中...</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // 使用共享预设匹配函数获取预设信息
+  const presetInfo = matchPreset(settings);
+
+  // 将布尔值转换为中文显示
+  const boolToText = (value) => value ? '是' : '否';
+
+  // 将主要设置项映射为中文
+  const settingLabels = {
+    // 时间范围
+    yearRange: {
+      label: '作品时间范围',
+      value: `${settings.startYear || '未设置'} - ${settings.endYear || '未设置'}`
+    },
+    // 热度设置
+    topNSubjects: {
+      label: '热度排行榜作品数',
+      value: settings.topNSubjects || '未设置'
+    },
+    useSubjectPerYear: {
+      label: '每年独立计算热度',
+      value: boolToText(settings.useSubjectPerYear)
+    },
+    // 筛选设置
+    metaTags: {
+      label: '分类筛选',
+      value: getMetaTagsText(settings.metaTags)
+    },
+    // 目录设置
+    useIndex: {
+      label: '使用指定目录',
+      value: boolToText(settings.useIndex)
+    },
+    indexId: {
+      label: '目录ID',
+      value: settings.indexId || '未使用'
+    },
+    // 角色设置
+    mainCharacterOnly: {
+      label: '仅主角',
+      value: boolToText(settings.mainCharacterOnly)
+    },
+    characterNum: {
+      label: '每个作品的角色数',
+      value: settings.characterNum || '默认'
+    },
+    // 游戏设置
+    maxAttempts: {
+      label: '最大尝试次数',
+      value: settings.maxAttempts || '10'
+    },
+    enableHints: {
+      label: '启用提示',
+      value: boolToText(settings.enableHints)
+    },
+    includeGame: {
+      label: '包含游戏作品',
+      value: boolToText(settings.includeGame)
+    },
+    timeLimit: {
+      label: '时间限制',
+      value: settings.timeLimit ? `${settings.timeLimit}秒` : '无限制'
+    },
+    subjectSearch: {
+      label: '启用作品搜索',
+      value: boolToText(settings.subjectSearch)
+    },
+    // 标签设置
+    characterTagNum: {
+      label: '角色标签数量',
+      value: settings.characterTagNum || '默认'
+    },
+    subjectTagNum: {
+      label: '作品标签数量',
+      value: settings.subjectTagNum || '默认'
+    }
+  };
+
+  // 解析元标签
+  function getMetaTagsText(metaTags) {
+    if (!metaTags || !Array.isArray(metaTags) || metaTags.length === 0) return '无';
+    
+    const validTags = metaTags.filter(tag => tag && typeof tag === 'string' && tag.trim() !== '');
+    if (validTags.length === 0) return '无';
+    
+    return validTags.join('、');
+  }
+
+  // 根据设置类型对设置项进行分组
+  const settingGroups = {
+    '作品范围': ['yearRange', 'topNSubjects', 'useSubjectPerYear', 'metaTags'],
+    '目录设置': ['useIndex', 'indexId'],
+    '角色设置': ['mainCharacterOnly', 'characterNum', 'characterTagNum'],
+    '游戏规则': ['maxAttempts', 'enableHints', 'timeLimit', 'subjectSearch', 'includeGame', 'subjectTagNum']
+  };
+
+  const toggleExpand = () => {
+    if (collapsible) {
+      setIsExpanded(!isExpanded);
+    }
+  };
+
+  return (
+    <div className="game-settings-display">
+      <div 
+        className={`settings-display-header ${collapsible ? 'collapsible' : ''}`}
+        onClick={toggleExpand}
+      >
+        <div className="settings-title-container">
+          <h3>{title}</h3>
+          {presetInfo.name && (
+            <div className="preset-info">
+              <span className="preset-name">{presetInfo.name}</span>
+              {presetInfo.modified && (
+                <span className="preset-modified">(房主有修改此预设)</span>
+              )}
+            </div>
+          )}
+        </div>
+        {collapsible && (
+          <span className={`expand-icon ${isExpanded ? 'expanded' : ''}`}>
+            {isExpanded ? '▼' : '▶'}
+          </span>
+        )}
+      </div>
+
+      {(isExpanded || !collapsible) && (
+        <div className="settings-display-content">
+          {Object.entries(settingGroups).map(([groupName, settingKeys]) => (
+            <div key={groupName} className="settings-group">
+              <h4>{groupName}</h4>
+              <div className="settings-items">
+                {settingKeys.map(key => (
+                  <div key={key} className="settings-item" data-key={key}>
+                    <span className="setting-label">{settingLabels[key].label}:</span>
+                    <span className="setting-value">{settingLabels[key].value}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default GameSettingsDisplay;

--- a/client_v3/src/components/SettingsPopup.jsx
+++ b/client_v3/src/components/SettingsPopup.jsx
@@ -2,6 +2,7 @@ import '../styles/popups.css';
 import { getIndexInfo, searchSubjects } from '../utils/anime';
 import { useState, useEffect, useRef } from 'react';
 import axiosCache from '../utils/cached-axios';
+import { getPresetConfig } from '../data/presets';
 
 function SettingsPopup({ gameSettings, onSettingsChange, onClose, onRestart, hideRestart = false }) {
   const [indexInputValue, setIndexInputValue] = useState('');
@@ -141,6 +142,25 @@ function SettingsPopup({ gameSettings, onSettingsChange, onClose, onRestart, hid
     alert('缓存已清空！');
   }
 
+  const applyPresetConfig = async (presetName) => {
+    const presetConfig = getPresetConfig(presetName);
+    if (!presetConfig) return;
+    
+    // 处理所有普通配置项
+    Object.entries(presetConfig).forEach(([key, value]) => {
+      if (key !== 'indexId') { // 特殊处理indexId
+        onSettingsChange(key, value);
+      }
+    });
+    
+    // 特殊处理indexId，确保使用setIndex函数
+    if (presetConfig.useIndex && presetConfig.indexId) {
+      await setIndex(presetConfig.indexId);
+    } else {
+      await setIndex(""); // 清除索引
+    }
+  };
+
   return (
     <div className="popup-overlay">
       <div className="popup-content">
@@ -159,137 +179,42 @@ function SettingsPopup({ gameSettings, onSettingsChange, onClose, onRestart, hid
               <div className="presets-buttons">
                 <button 
                   className="preset-button"
-                  onClick={async () => {
-                    onSettingsChange('startYear', new Date().getFullYear()-5);
-                    onSettingsChange('endYear', new Date().getFullYear());
-                    onSettingsChange('topNSubjects', 20);
-                    onSettingsChange('useSubjectPerYear', false);
-                    onSettingsChange('metaTags', ["", "", ""]);
-                    onSettingsChange('useIndex', false);
-                    onSettingsChange('addedSubjects', []);
-                    onSettingsChange('mainCharacterOnly', true);
-                    onSettingsChange('characterNum', 3);
-                    onSettingsChange('maxAttempts', 10);
-                    await setIndex("");
-                    onSettingsChange('enableHints', true);
-                    onSettingsChange('includeGame', false);
-                    onSettingsChange('subjectSearch', true);
-                    onSettingsChange('subjectTagNum', 8);
-                    onSettingsChange('characterTagNum', 6);
-                  }}
+                  onClick={() => applyPresetConfig('入门')}
                 >
                   入门
                 </button>
                 <button 
                   className="preset-button"
-                  onClick={async () => {
-                    onSettingsChange('startYear', new Date().getFullYear()-20);
-                    onSettingsChange('endYear', new Date().getFullYear());
-                    onSettingsChange('topNSubjects', 5);
-                    onSettingsChange('useSubjectPerYear', true);
-                    onSettingsChange('metaTags', ["", "", ""]);
-                    onSettingsChange('useIndex', false);
-                    onSettingsChange('addedSubjects', []);
-                    onSettingsChange('mainCharacterOnly', false);
-                    onSettingsChange('characterNum', 6);
-                    onSettingsChange('maxAttempts', 10);
-                    await setIndex("");
-                    onSettingsChange('enableHints', false);
-                    onSettingsChange('includeGame', false);
-                    onSettingsChange('subjectSearch', false);
-                    onSettingsChange('subjectTagNum', 8);
-                    onSettingsChange('characterTagNum', 6);
-                  }}
+                  onClick={() => applyPresetConfig('冻鳗高手')}
                 >
                   冻鳗高手
                 </button>
                 <button 
                   className="preset-button"
-                  onClick={async () => {
-                    onSettingsChange('startYear', 2000);
-                    onSettingsChange('endYear', 2015);
-                    onSettingsChange('topNSubjects', 5);
-                    onSettingsChange('useSubjectPerYear', true);
-                    onSettingsChange('metaTags', ["", "", ""]);
-                    onSettingsChange('useIndex', false);
-                    onSettingsChange('addedSubjects', []);
-                    onSettingsChange('mainCharacterOnly', true);
-                    onSettingsChange('characterNum', 6);
-                    onSettingsChange('maxAttempts', 10);
-                    await setIndex("");
-                    onSettingsChange('enableHints', false);
-                    onSettingsChange('includeGame', false);
-                    onSettingsChange('subjectSearch', false);
-                    onSettingsChange('subjectTagNum', 8);
-                    onSettingsChange('characterTagNum', 6);
-                  }}
+                  onClick={() => applyPresetConfig('老番享受者')}
                 >
                   老番享受者
                 </button>
                 <button 
                   className="preset-button"
-                  onClick={async () => {
-                    onSettingsChange('startYear', 2005);
-                    onSettingsChange('endYear', new Date().getFullYear());
-                    onSettingsChange('topNSubjects', 75);
-                    onSettingsChange('useSubjectPerYear', false);
-                    onSettingsChange('metaTags', ["", "", ""]);
-                    onSettingsChange('addedSubjects', []);
-                    onSettingsChange('mainCharacterOnly', true);
-                    onSettingsChange('characterNum', 10);
-                    onSettingsChange('maxAttempts', 7);
-                    await setIndex("");
-                    onSettingsChange('enableHints', false);
-                    onSettingsChange('includeGame', false);
-                    onSettingsChange('subjectSearch', true);
-                    onSettingsChange('subjectTagNum', 8);
-                    onSettingsChange('characterTagNum', 5);
-                  }}
+                  onClick={() => applyPresetConfig('瓶子严选')}
                 >
                   瓶子严选
                 </button>
                 <button 
                   className="preset-button"
-                  onClick={async () => {
+                  onClick={() => {
                     alert('😅');
-                    onSettingsChange('startYear', new Date().getFullYear()-10);
-                    onSettingsChange('endYear', new Date().getFullYear());
-                    onSettingsChange('topNSubjects', 50);
-                    onSettingsChange('useSubjectPerYear', false);
-                    onSettingsChange('metaTags', ["", "", ""]);
-                    onSettingsChange('addedSubjects', []);
-                    onSettingsChange('mainCharacterOnly', true);
-                    onSettingsChange('characterNum', 6);
-                    onSettingsChange('maxAttempts', 10);
-                    await setIndex("75522");
-                    onSettingsChange('enableHints', false);
-                    onSettingsChange('includeGame', false);
-                    onSettingsChange('subjectSearch', false);
-                    onSettingsChange('subjectTagNum', 8);
-                    onSettingsChange('characterTagNum', 6);
+                    applyPresetConfig('木柜子痴');
                   }}
                 >
                   木柜子痴
                 </button>
                 <button 
                   className="preset-button"
-                  onClick={async () => {
+                  onClick={() => {
                     alert('那很有生活了😅');
-                    onSettingsChange('startYear', new Date().getFullYear()-10);
-                    onSettingsChange('endYear', new Date().getFullYear());
-                    onSettingsChange('topNSubjects', 50);
-                    onSettingsChange('useSubjectPerYear', false);
-                    onSettingsChange('metaTags', ["", "", ""]);
-                    onSettingsChange('addedSubjects', []);
-                    onSettingsChange('mainCharacterOnly', false);
-                    onSettingsChange('characterNum', 10);
-                    onSettingsChange('maxAttempts', 10);
-                    await setIndex("75442");
-                    onSettingsChange('enableHints', false);
-                    onSettingsChange('includeGame', true);
-                    onSettingsChange('subjectSearch', false);
-                    onSettingsChange('subjectTagNum', 3);
-                    onSettingsChange('characterTagNum', 6);
+                    applyPresetConfig('二游高手+');
                   }}
                 >
                   二游高手+

--- a/client_v3/src/data/presets.js
+++ b/client_v3/src/data/presets.js
@@ -1,0 +1,246 @@
+/**
+ * 游戏预设配置
+ * 包含所有预设及其配置项
+ */
+
+// 获取当前年份
+const currentYear = new Date().getFullYear();
+
+// 游戏预设配置
+export const gamePresets = {
+  '入门': {
+    startYear: currentYear - 5,
+    endYear: currentYear,
+    topNSubjects: 20,
+    useSubjectPerYear: false,
+    metaTags: ["", "", ""],
+    useIndex: false,
+    indexId: null,
+    addedSubjects: [],
+    mainCharacterOnly: true,
+    characterNum: 3,
+    maxAttempts: 10,
+    enableHints: true,
+    includeGame: false,
+    subjectSearch: true,
+    subjectTagNum: 8,
+    characterTagNum: 6,
+    // 标记哪些字段是动态计算的
+    dynamicFields: ['startYear', 'endYear']
+  },
+  '冻鳗高手': {
+    startYear: currentYear - 20,
+    endYear: currentYear,
+    topNSubjects: 5,
+    useSubjectPerYear: true,
+    metaTags: ["", "", ""],
+    useIndex: false,
+    indexId: null,
+    addedSubjects: [],
+    mainCharacterOnly: false,
+    characterNum: 6,
+    maxAttempts: 10,
+    enableHints: false,
+    includeGame: false,
+    subjectSearch: false,
+    subjectTagNum: 8,
+    characterTagNum: 6,
+    dynamicFields: ['startYear', 'endYear']
+  },
+  '老番享受者': {
+    startYear: 2000,
+    endYear: 2015,
+    topNSubjects: 5,
+    useSubjectPerYear: true,
+    metaTags: ["", "", ""],
+    useIndex: false,
+    indexId: null,
+    addedSubjects: [],
+    mainCharacterOnly: true,
+    characterNum: 6,
+    maxAttempts: 10,
+    enableHints: false,
+    includeGame: false,
+    subjectSearch: false,
+    subjectTagNum: 8,
+    characterTagNum: 6,
+    dynamicFields: []
+  },
+  '瓶子严选': {
+    startYear: 2005,
+    endYear: currentYear,
+    topNSubjects: 75,
+    useSubjectPerYear: false,
+    metaTags: ["", "", ""],
+    addedSubjects: [],
+    mainCharacterOnly: true,
+    characterNum: 10,
+    maxAttempts: 7,
+    enableHints: false,
+    includeGame: false,
+    subjectSearch: true,
+    subjectTagNum: 8,
+    characterTagNum: 5,
+    dynamicFields: ['endYear']
+  },
+  '木柜子痴': {
+    startYear: currentYear - 10,
+    endYear: currentYear,
+    topNSubjects: 50,
+    useSubjectPerYear: false,
+    metaTags: ["", "", ""],
+    addedSubjects: [],
+    mainCharacterOnly: true,
+    characterNum: 6,
+    maxAttempts: 10,
+    useIndex: true,
+    indexId: "75522",
+    enableHints: false,
+    includeGame: false,
+    subjectSearch: false,
+    subjectTagNum: 8,
+    characterTagNum: 6,
+    dynamicFields: ['startYear', 'endYear']
+  },
+  '二游高手+': {
+    startYear: currentYear - 10,
+    endYear: currentYear,
+    topNSubjects: 50,
+    useSubjectPerYear: false,
+    metaTags: ["", "", ""],
+    addedSubjects: [],
+    mainCharacterOnly: false,
+    characterNum: 10,
+    maxAttempts: 10,
+    useIndex: true,
+    indexId: "75442",
+    enableHints: false,
+    includeGame: true,
+    subjectSearch: false,
+    subjectTagNum: 3,
+    characterTagNum: 6,
+    dynamicFields: ['startYear', 'endYear']
+  }
+};
+
+/**
+ * 判断两个值是否匹配，考虑动态年份
+ * @param {any} settingValue - 当前设置的值
+ * @param {any} presetValue - 预设配置的值
+ * @param {string} key - 设置项的键名
+ * @param {Array} dynamicFields - 动态计算的字段列表
+ * @returns {boolean} - 是否匹配
+ */
+function isValueMatch(settingValue, presetValue, key, dynamicFields) {
+  // 处理动态年份字段
+  if (dynamicFields.includes(key)) {
+    if (key === 'startYear') {
+      // 计算动态年份，允许1年的误差
+      const isYearMatch = Math.abs(settingValue - presetValue) <= 1;
+      return isYearMatch;
+    }
+    if (key === 'endYear') {
+      // 如果预设的结束年份是当前年份，允许误差
+      if (presetValue === currentYear) {
+        return Math.abs(settingValue - currentYear) <= 1;
+      }
+    }
+  }
+  
+  // 处理数组类型
+  if (Array.isArray(settingValue) && Array.isArray(presetValue)) {
+    return JSON.stringify(settingValue) === JSON.stringify(presetValue);
+  }
+  
+  // 处理普通类型
+  return settingValue === presetValue;
+}
+
+/**
+ * 匹配当前设置是否符合某个预设
+ * @param {Object} settings - 当前游戏设置
+ * @returns {Object} - 匹配的预设信息 { name, modified }
+ */
+export function matchPreset(settings) {
+  if (!settings) return { name: null, modified: false };
+  
+  // 关键设置项，用于确定预设类型
+  const keySettings = [
+    'useIndex', 'indexId', 'topNSubjects', 'useSubjectPerYear', 
+    'mainCharacterOnly', 'characterNum', 'maxAttempts', 
+    'enableHints', 'includeGame', 'subjectSearch'
+  ];
+  
+  // 所有设置项，用于检查是否有修改
+  const allSettings = [
+    ...keySettings, 
+    'startYear', 'endYear', 'metaTags', 
+    'characterTagNum', 'subjectTagNum'
+  ];
+  
+  // 尝试匹配每个预设
+  for (const [presetName, presetConfig] of Object.entries(gamePresets)) {
+    // 从预设配置中提取动态字段列表
+    const dynamicFields = presetConfig.dynamicFields || [];
+    
+    // 步骤1: 检查关键设置项是否匹配
+    let isMatch = true;
+    for (const key of keySettings) {
+      const settingValue = settings[key];
+      const presetValue = presetConfig[key];
+      
+      if (!isValueMatch(settingValue, presetValue, key, dynamicFields)) {
+        isMatch = false;
+        break;
+      }
+    }
+    
+    // 如果关键设置项匹配，检查是否有修改
+    if (isMatch) {
+      let hasModifications = false;
+      
+      for (const key of allSettings) {
+        const settingValue = settings[key];
+        const presetValue = presetConfig[key];
+        
+        if (!isValueMatch(settingValue, presetValue, key, dynamicFields)) {
+          hasModifications = true;
+          break;
+        }
+      }
+      
+      return {
+        name: presetName,
+        modified: hasModifications
+      };
+    }
+  }
+  
+  // 没有找到匹配的预设
+  return {
+    name: null,
+    modified: false
+  };
+}
+
+/**
+ * 获取预设对象的副本
+ * @param {string} presetName - 预设名称
+ * @returns {Object} - 预设配置的副本
+ */
+export function getPresetConfig(presetName) {
+  if (!gamePresets[presetName]) return null;
+  
+  // 创建预设的深拷贝，移除dynamicFields字段
+  const presetCopy = JSON.parse(JSON.stringify(gamePresets[presetName]));
+  delete presetCopy.dynamicFields;
+  return presetCopy;
+}
+
+/**
+ * 获取所有预设名称
+ * @returns {Array} - 预设名称列表
+ */
+export function getPresetNames() {
+  return Object.keys(gamePresets);
+} 

--- a/client_v3/src/pages/Multiplayer.jsx
+++ b/client_v3/src/pages/Multiplayer.jsx
@@ -10,6 +10,7 @@ import Timer from '../components/Timer';
 import PlayerList from '../components/PlayerList';
 import GameEndPopup from '../components/GameEndPopup';
 import SetAnswerPopup from '../components/SetAnswerPopup';
+import GameSettingsDisplay from '../components/GameSettingsDisplay';
 import '../styles/Multiplayer.css';
 import '../styles/game.css';
 import CryptoJS from 'crypto-js';
@@ -33,7 +34,7 @@ const Multiplayer = () => {
   const [isManualMode, setIsManualMode] = useState(false);
   const [answerSetterId, setAnswerSetterId] = useState(null);
   const [waitingForAnswer, setWaitingForAnswer] = useState(false);
-  const [gameSettings, setGameSettings, removeGameSettings] = useLocalStorage('multiplayer-game-settings', {
+  const [gameSettings, setGameSettings] = useLocalStorage('multiplayer-game-settings', {
     startYear: new Date().getFullYear()-5,
     endYear: new Date().getFullYear(),
     topNSubjects: 20,
@@ -597,9 +598,13 @@ const Multiplayer = () => {
                 </div>
               )}
               {!isHost && (
-                <div className="game-settings-display">
-                  <pre>{JSON.stringify(gameSettings, null, 2)}</pre>
-                </div>
+                <>
+                  {/* 调试信息*/}
+                  {/* <pre style={{ fontSize: '12px', color: '#666', padding: '5px', background: '#f5f5f5' }}>
+                    {JSON.stringify({...gameSettings, __debug: '显示原始数据用于调试'}, null, 2)}
+                  </pre> */}
+                  <GameSettingsDisplay settings={gameSettings} />
+                </>
               )}
             </>
           )}
@@ -739,9 +744,13 @@ const Multiplayer = () => {
               </div>
               <div className="game-end-container">
                 {!isHost && (
-                  <div className="game-settings-display">
-                    <pre>{JSON.stringify(gameSettings, null, 2)}</pre>
-                  </div>
+                  <>
+                    {/* 调试信息*/}
+                    {/* <pre style={{ fontSize: '12px', color: '#666', padding: '5px', background: '#f5f5f5' }}>
+                      {JSON.stringify({...gameSettings, __debug: '显示原始数据用于调试'}, null, 2)}
+                    </pre> */}
+                    <GameSettingsDisplay settings={gameSettings} />
+                  </>
                 )}
                 <div className="guess-history-table">
                   <table>

--- a/client_v3/src/styles/GameSettingsDisplay.css
+++ b/client_v3/src/styles/GameSettingsDisplay.css
@@ -1,0 +1,155 @@
+/* 这是多人模式参与者观看设置显示的样式 */
+.game-settings-display {
+  width: 100%;
+  max-width: 800px;
+  margin: 1rem auto;
+  background-color: white;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+}
+
+.settings-display-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 15px 20px;
+  background-color: #f1f5f9;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.settings-display-header.collapsible {
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+}
+
+.settings-display-header.collapsible:hover {
+  background-color: #e2e8f0;
+}
+
+.settings-display-header h3 {
+  margin: 0;
+  color: #334155;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.expand-icon {
+  color: #64748b;
+  font-size: 14px;
+  transition: transform 0.3s ease;
+}
+
+.expand-icon.expanded {
+  transform: rotate(0deg);
+}
+
+.settings-display-content {
+  padding: 0;
+}
+
+.settings-group {
+  padding: 16px 20px;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.settings-group:last-child {
+  border-bottom: none;
+}
+
+.settings-group h4 {
+  margin: 0 0 12px 0;
+  color: #475569;
+  font-size: 16px;
+  font-weight: 500;
+  border-left: 3px solid #3b82f6;
+  padding-left: 10px;
+}
+
+.settings-items {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 10px 20px;
+}
+
+.settings-item {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 8px;
+}
+
+.setting-label {
+  color: #64748b;
+  font-size: 14px;
+  margin-bottom: 2px;
+}
+
+.setting-value {
+  color: #334155;
+  font-size: 16px;
+  font-weight: 500;
+}
+
+/* 高亮一些重要的设置项 */
+/* 使用更基本的选择器，不依赖:has和:contains，提高浏览器兼容性 */
+.settings-item[data-key="indexId"] .setting-value,
+.settings-item[data-key="yearRange"] .setting-value,
+.settings-item[data-key="maxAttempts"] .setting-value,
+.settings-item[data-key="timeLimit"] .setting-value {
+  color: #3b82f6;
+}
+
+/* 响应式样式 */
+@media (max-width: 640px) {
+  .game-settings-display {
+    margin: 1rem 10px;
+  }
+  
+  .settings-display-header {
+    padding: 12px 15px;
+  }
+  
+  .settings-display-header h3 {
+    font-size: 16px;
+  }
+  
+  .settings-group {
+    padding: 12px 15px;
+  }
+  
+  .settings-items {
+    grid-template-columns: 1fr;
+  }
+  
+  .setting-value {
+    font-size: 15px;
+  }
+}
+
+.settings-title-container {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.preset-info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 4px;
+  font-size: 14px;
+}
+
+.preset-name {
+  color: #3b82f6;
+  font-weight: 500;
+  padding: 2px 8px;
+  background-color: rgba(59, 130, 246, 0.1);
+  border-radius: 4px;
+}
+
+.preset-modified {
+  color: #f59e0b;
+  font-size: 12px;
+  font-style: italic;
+} 


### PR DESCRIPTION
多人模式参与者视角在显示房间设置时，标题右侧会显示当前使用的预设名称，如果预设被修改过，还会显示"(房主有修改此预设)"的提示
简化了添加新预设的流程，如果未来需要添加新预设，只需要在presets.js文件中添加一个新的预设配置，然后在SettingsPopup组件中添加对应的按钮



原始
![b2144b08c3261dfe3df4c31e3f1c1d88](https://github.com/user-attachments/assets/0c0c7c2c-2b59-461e-b71b-aec33e24490f)
改动后
![image](https://github.com/user-attachments/assets/07b855e2-65f0-4bb6-81ba-443861fd5028)
![image](https://github.com/user-attachments/assets/0bd225d5-86db-490e-82e5-3726d9f67c37)
