### PR TITLE
feat:房主权限转移功能，允许房主将权限转移给其他玩家

### DIFF
--- a/client_v3/src/components/PlayerList.jsx
+++ b/client_v3/src/components/PlayerList.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-const PlayerList = ({ players, socket, isGameStarted, handleReadyToggle, onAnonymousModeChange, isManualMode, isHost, answerSetterId, onSetAnswerSetter, onKickPlayer }) => {
+const PlayerList = ({ players, socket, isGameStarted, handleReadyToggle, onAnonymousModeChange, isManualMode, isHost, answerSetterId, onSetAnswerSetter, onKickPlayer, onTransferHost }) => {
   const [showNames, setShowNames] = useState(true);
   const [waitingForAnswer, setWaitingForAnswer] = useState(false);
 
@@ -79,6 +79,13 @@ const PlayerList = ({ players, socket, isGameStarted, handleReadyToggle, onAnony
     }
   };
 
+  const handleTransferHostClick = (e, playerId) => {
+    e.stopPropagation(); // 阻止事件冒泡，防止触发行点击事件
+    if (onTransferHost) {
+      onTransferHost(playerId);
+    }
+  };
+
   return (
     <div className="players-list">
       <table className="score-table">
@@ -105,7 +112,7 @@ const PlayerList = ({ players, socket, isGameStarted, handleReadyToggle, onAnony
             </th>
             <th>分</th>
             <th>猜</th>
-            {isHost && <th></th>} 
+            {isHost && <th>操作</th>} 
           </tr>
         </thead>
         <tbody>
@@ -133,21 +140,40 @@ const PlayerList = ({ players, socket, isGameStarted, handleReadyToggle, onAnony
               <td>{isGameStarted && player.isAnswerSetter ? '出题者' : player.guesses || ''}</td>
               {isHost && player.id !== socket?.id && (
                 <td>
-                  {player.disconnected && (
+                  {player.disconnected ? (
                     <button 
                       onClick={(e) => handleKickClick(e, player.id)}
                       className="kick-button"
                       title="踢出断开连接的玩家"
                       style={{
-                        background: 'none',
-                        border: 'none',
+                        background: '#ffebeb',
+                        border: '1px solid #dc3545',
+                        borderRadius: '4px',
                         cursor: 'pointer',
-                        color: 'red',
+                        color: '#dc3545',
+                        fontSize: '14px',
+                        padding: '2px 6px',
+                        marginRight: '5px'
+                      }}
+                    >
+                      踢出
+                    </button>
+                  ) : (
+                    <button 
+                      onClick={(e) => handleTransferHostClick(e, player.id)}
+                      className="transfer-host-button"
+                      title="将房主权限转移给该玩家"
+                      style={{
+                        background: '#e6f3ff',
+                        border: '1px solid #007bff',
+                        borderRadius: '4px',
+                        cursor: 'pointer',
+                        color: '#007bff',
                         fontSize: '14px',
                         padding: '2px 6px'
                       }}
                     >
-                      踢出
+                      转移房主
                     </button>
                   )}
                 </td>

--- a/client_v3/src/pages/Multiplayer.jsx
+++ b/client_v3/src/pages/Multiplayer.jsx
@@ -156,6 +156,16 @@ const Multiplayer = () => {
       navigate('/multiplayer');
     });
 
+    newSocket.on('hostTransferred', ({ oldHostName, newHostId, newHostName }) => {
+      // 如果当前用户是新房主，则更新状态
+      if (newHostId === newSocket.id) {
+        setIsHost(true);
+        alert(`房主 ${oldHostName} 已断开连接，你已成为新房主！`);
+      } else {
+        alert(`房主 ${oldHostName} 已断开连接，${newHostName} 已成为新房主。`);
+      }
+    });
+
     newSocket.on('error', ({ message }) => {
       alert(`错误: ${message}`);
       setError(message);
@@ -514,11 +524,19 @@ const Multiplayer = () => {
   const handleKickPlayer = (playerId) => {
     if (!isHost || !socket) return;
     
-    const playerToKick = players.find(p => p.id === playerId);
-    if (!playerToKick) return;
-
-    if (confirm(`确定要踢出断开连接的玩家 ${playerToKick.username} 吗？`)) {
+    // 确认后再踢出
+    if (window.confirm('确定要踢出该玩家吗？')) {
       socket.emit('kickPlayer', { roomId, playerId });
+    }
+  };
+
+  const handleTransferHost = (playerId) => {
+    if (!isHost || !socket) return;
+    
+    // 确认后再转移房主
+    if (window.confirm('确定要将房主权限转移给该玩家吗？')) {
+      socket.emit('transferHost', { roomId, newHostId: playerId });
+      setIsHost(false);
     }
   };
 
@@ -568,6 +586,7 @@ const Multiplayer = () => {
                 answerSetterId={answerSetterId}
                 onSetAnswerSetter={handleSetAnswerSetter}
                 onKickPlayer={handleKickPlayer}
+                onTransferHost={handleTransferHost}
               />
 
           {!isGameStarted && !globalGameEnd && (


### PR DESCRIPTION
#  如题
![d3e39cfed1f4ac2f0074f6469f6088e9](https://github.com/user-attachments/assets/6b6bb9dc-8e10-4f65-bad4-33abad62eee8)
![68da40dd83777b8f1fd0085439ff9c21](https://github.com/user-attachments/assets/ebf8f872-b52f-45ae-aac4-08f5b5ea9973)
![d415eb351f456da9e8d131ae59e1d7b4](https://github.com/user-attachments/assets/22af1d50-708c-4176-957b-8836aa262221)
## 将新增的栏命名为“操作”，同时修改‘踢出‘和’移交房主‘按钮的style