### PR TITLE
fix:对于多人游戏中房主的操作功能修改

### DIFF
--- a/client_v3/src/components/PlayerList.jsx
+++ b/client_v3/src/components/PlayerList.jsx
@@ -1,11 +1,12 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 const PlayerList = ({ players, socket, isGameStarted, handleReadyToggle, onAnonymousModeChange, isManualMode, isHost, answerSetterId, onSetAnswerSetter, onKickPlayer, onTransferHost }) => {
   const [showNames, setShowNames] = useState(true);
   const [waitingForAnswer, setWaitingForAnswer] = useState(false);
+  const [activeMenu, setActiveMenu] = useState(null);
 
   // Add socket event listener for waitForAnswer
-  React.useEffect(() => {
+ useEffect(() => {
     if (socket) {
       socket.on('waitForAnswer', () => {
         setWaitingForAnswer(true);
@@ -17,6 +18,20 @@ const PlayerList = ({ players, socket, isGameStarted, handleReadyToggle, onAnony
       });
     }
   }, [socket]);
+
+  // Add click outside handler to close menu
+  useEffect(() => {
+    function handleClickOutside(event) {
+      if (activeMenu && !event.target.closest('.player-actions')) {
+        setActiveMenu(null);
+      }
+    }
+    
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [activeMenu]);
 
   const handleShowNamesToggle = () => {
     const newShowNames = !showNames;
@@ -140,42 +155,90 @@ const PlayerList = ({ players, socket, isGameStarted, handleReadyToggle, onAnony
               <td>{isGameStarted && player.isAnswerSetter ? '出题者' : player.guesses || ''}</td>
               {isHost && player.id !== socket?.id && (
                 <td>
-                  {player.disconnected ? (
+                  <div className="player-actions" style={{ position: 'relative' }}>
                     <button 
-                      onClick={(e) => handleKickClick(e, player.id)}
-                      className="kick-button"
-                      title="踢出断开连接的玩家"
+                      className="action-menu-button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        // 切换显示该玩家的操作菜单
+                        setActiveMenu(activeMenu === player.id ? null : player.id);
+                      }}
                       style={{
-                        background: '#ffebeb',
-                        border: '1px solid #dc3545',
+                        background: '#f8f9fa',
+                        border: '1px solid #dee2e6',
                         borderRadius: '4px',
                         cursor: 'pointer',
-                        color: '#dc3545',
+                        color: '#212529',
+                        padding: '4px 8px',
                         fontSize: '14px',
-                        padding: '2px 6px',
-                        marginRight: '5px'
+                        minWidth: '70px',
                       }}
                     >
-                      踢出
+                      ⚙️ 操作
                     </button>
-                  ) : (
-                    <button 
-                      onClick={(e) => handleTransferHostClick(e, player.id)}
-                      className="transfer-host-button"
-                      title="将房主权限转移给该玩家"
-                      style={{
-                        background: '#e6f3ff',
-                        border: '1px solid #007bff',
+                    
+                    {activeMenu === player.id && (
+                      <div className="action-dropdown" style={{
+                        position: 'absolute',
+                        background: 'white',
+                        border: '1px solid #dee2e6',
                         borderRadius: '4px',
-                        cursor: 'pointer',
-                        color: '#007bff',
-                        fontSize: '14px',
-                        padding: '2px 6px'
-                      }}
-                    >
-                      转移房主
-                    </button>
-                  )}
+                        boxShadow: '0 2px 5px rgba(0,0,0,0.15)',
+                        zIndex: 100,
+                        width: '120px',
+                        right: 0,
+                        top: '100%',
+                        marginTop: '4px',
+                      }}>
+                        <button 
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleKickClick(e, player.id);
+                            setActiveMenu(null);
+                          }}
+                          style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: '8px',
+                            width: '100%',
+                            padding: '8px 12px',
+                            border: 'none',
+                            background: 'none',
+                            textAlign: 'left',
+                            cursor: 'pointer',
+                            color: '#dc3545',
+                            borderBottom: '1px solid #eee',
+                          }}
+                        >
+                          <span>❌</span> 踢出
+                        </button>
+                        
+                        {!player.disconnected && (
+                          <button 
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleTransferHostClick(e, player.id);
+                              setActiveMenu(null);
+                            }}
+                            style={{
+                              display: 'flex',
+                              alignItems: 'center',
+                              gap: '8px',
+                              width: '100%',
+                              padding: '8px 12px',
+                              border: 'none',
+                              background: 'none',
+                              textAlign: 'left',
+                              cursor: 'pointer',
+                              color: '#007bff',
+                            }}
+                          >
+                            <span>👑</span> 转移房主
+                          </button>
+                        )}
+                      </div>
+                    )}
+                  </div>
                 </td>
               )}
             </tr>

--- a/client_v3/src/pages/Multiplayer.jsx
+++ b/client_v3/src/pages/Multiplayer.jsx
@@ -79,11 +79,15 @@ const Multiplayer = () => {
   const [showCharacterPopup, setShowCharacterPopup] = useState(false);
   const [showSetAnswerPopup, setShowSetAnswerPopup] = useState(false);
   const [isAnswerSetter, setIsAnswerSetter] = useState(false);
+  const [kickNotification, setKickNotification] = useState(null);
 
   useEffect(() => {
     // Initialize socket connection
     const newSocket = io(SOCKET_URL);
     setSocket(newSocket);
+
+    // 用于追踪事件是否已经被处理
+    const kickEventProcessed = {}; 
 
     // Socket event listeners
     newSocket.on('updatePlayers', ({ players, isPublic, answerSetterId }) => {
@@ -165,12 +169,12 @@ const Multiplayer = () => {
       if (newHostId === newSocket.id) {
         setIsHost(true);
         if (oldHostName === newHostName) {
-          alert(`原房主已断开连接，你已成为新房主！`);
+          showKickNotification(`原房主已断开连接，你已成为新房主！`, 'host');
         } else {
-          alert(`房主 ${oldHostName} 已断开连接，你已成为新房主！`);
+          showKickNotification(`房主 ${oldHostName} 已将房主权限转移给你！`, 'host');
         }
       } else {
-        alert(`房主 ${oldHostName} 已断开连接，${newHostName} 已成为新房主。`);
+        showKickNotification(`房主权限已从 ${oldHostName} 转移给 ${newHostName}`, 'host');
       }
     });
 
@@ -200,15 +204,39 @@ const Multiplayer = () => {
     });
 
     newSocket.on('playerKicked', ({ playerId, username }) => {
+      // 使用唯一标识确保同一事件不会处理多次
+      const eventId = `${playerId}-${Date.now()}`;
+      if (kickEventProcessed[eventId]) return;
+      kickEventProcessed[eventId] = true;
+      
       if (playerId === newSocket.id) {
-        alert(`你已被房主踢出房间。`);
-        navigate('/multiplayer');
+        // 如果当前玩家被踢出，显示通知并重定向到多人游戏大厅
+        showKickNotification('你已被房主踢出房间', 'kick');
+        setIsJoined(false); 
+        setGameEnd(true); 
+        setTimeout(() => {
+          navigate('/multiplayer');
+        }, 100); // 延长延迟时间确保通知显示后再跳转
       } else {
-        alert(`玩家 ${username} 已被踢出房间。`);
+        showKickNotification(`玩家 ${username} 已被踢出房间`, 'kick');
+        setPlayers(prevPlayers => prevPlayers.filter(p => p.id !== playerId));
       }
     });
 
     return () => {
+      // 清理事件监听和连接
+      newSocket.off('playerKicked');
+      newSocket.off('hostTransferred');
+      newSocket.off('updatePlayers');
+      newSocket.off('waitForAnswer');
+      newSocket.off('gameStart');
+      newSocket.off('guessHistoryUpdate');
+      newSocket.off('roomClosed');
+      newSocket.off('error');
+      newSocket.off('updateGameSettings');
+      newSocket.off('gameEnded');
+      newSocket.off('resetReadyStatus');
+      
       newSocket.disconnect();
     };
   }, [navigate]);
@@ -528,9 +556,27 @@ const Multiplayer = () => {
   const handleKickPlayer = (playerId) => {
     if (!isHost || !socket) return;
     
+    // 确认当前玩家是房主
+    const currentPlayer = players.find(p => p.id === socket.id);
+    if (!currentPlayer || !currentPlayer.isHost) {
+      alert('只有房主可以踢出玩家');
+      return;
+    }
+    
+    // 防止房主踢出自己
+    if (playerId === socket.id) {
+      alert('房主不能踢出自己');
+      return;
+    }
+    
     // 确认后再踢出
     if (window.confirm('确定要踢出该玩家吗？')) {
-      socket.emit('kickPlayer', { roomId, playerId });
+      try {
+        socket.emit('kickPlayer', { roomId, playerId });
+      } catch (error) {
+        console.error('踢出玩家失败:', error);
+        alert('踢出玩家失败，请重试');
+      }
     }
   };
 
@@ -561,12 +607,29 @@ const Multiplayer = () => {
     }
   };
 
+  // 创建一个函数显示踢出通知
+  const showKickNotification = (message, type = 'kick') => {
+    setKickNotification({ message, type });
+    setTimeout(() => {
+      setKickNotification(null);
+    }, 5000); // 5秒后自动关闭通知
+  };
+
   if (!roomId) {
     return <div>Loading...</div>;
   }
 
   return (
     <div className="multiplayer-container">
+      {/* 添加踢出通知 */}
+      {kickNotification && (
+        <div className={`kick-notification ${kickNotification.type === 'host' ? 'host-notification' : ''}`}>
+          <div className="kick-notification-content">
+            <i className={`fas ${kickNotification.type === 'host' ? 'fa-crown' : 'fa-exclamation-circle'}`}></i>
+            <span>{kickNotification.message}</span>
+          </div>
+        </div>
+      )}
       <a
           href="/"
           className="social-link floating-back-button"

--- a/client_v3/src/styles/Multiplayer.css
+++ b/client_v3/src/styles/Multiplayer.css
@@ -555,3 +555,48 @@
   color: #666;
   font-style: italic;
 }
+
+/* 踢出通知样式 */
+.kick-notification {
+  position: fixed;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1000;
+  background-color: rgba(220, 53, 69, 0.9);
+  color: white;
+  border-radius: 8px;
+  padding: 15px 20px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  animation: notification-slide-in 0.3s ease-out;
+  max-width: 90%;
+  min-width: 300px;
+}
+
+/* 房主转移通知样式 */
+.kick-notification.host-notification {
+  background-color: rgba(74, 144, 226, 0.9);
+}
+
+.kick-notification-content {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 16px;
+  font-weight: 500;
+}
+
+.kick-notification i {
+  font-size: 20px;
+}
+
+@keyframes notification-slide-in {
+  from {
+    transform: translateX(-50%) translateY(-100px);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(-50%) translateY(0);
+    opacity: 1;
+  }
+}

--- a/server_v3/.env.lan
+++ b/server_v3/.env.lan
@@ -1,8 +1,0 @@
-PORT=8000
-
-# 客户端URL（用于CORS）
-CLIENT_URL=http://localhost:5173
-SERVER_URL=http://localhost:8000
-
-# 数据服务器URL
-DB_SERVER_URL=http://localhost:8001

--- a/server_v3/.env.lan
+++ b/server_v3/.env.lan
@@ -1,0 +1,8 @@
+PORT=8000
+
+# 客户端URL（用于CORS）
+CLIENT_URL=http://localhost:5173
+SERVER_URL=http://localhost:8000
+
+# 数据服务器URL
+DB_SERVER_URL=http://localhost:8001


### PR DESCRIPTION
# 优化了踢出和移交房主的操作和显示
 现在房主可踢出**任意**玩家（_之前只能踢出断连玩家_）
 将alert对话框改为为自定义通知组件
效果见图
![f2168ab08dc54d566c72a73124bd9d04](https://github.com/user-attachments/assets/42f48fdb-d766-4679-adc5-5a703d7b61a9)
![8ba7943cae8be960dc1f69f5d67b97bd](https://github.com/user-attachments/assets/dbbb2ee6-4d3b-4f1b-8c66-9f5a7584c9af)
![f14399b2fb4dfc790a66250e3a4d30e8](https://github.com/user-attachments/assets/b1220d70-186f-400d-b358-28da4aae5ad8)

