### PR TITLE
fix 在单人计时模式下，投降或一局结束关闭答案角色页面后，点“再玩一次”后并非从设定计时开始 #89

### DIFF
--- a/client_v3/src/pages/SinglePlayer.jsx
+++ b/client_v3/src/pages/SinglePlayer.jsx
@@ -240,7 +240,7 @@ function SinglePlayer() {
     setGameEndPopup(null);
     setAnswerCharacter(null);
     setSettingsPopup(false);
-    setShouldResetTimer(false);
+    setShouldResetTimer(true);
     setFinishInit(false);
     setHints({
       first: null,


### PR DESCRIPTION
修复#89 中的问题
只改个setShouldResetTimer(true)貌似就行了

现在这个Timer总感觉怪怪的，
好像点击再玩一次初始化游戏和点击搜索出来的角色都会阻塞Timer的刷新？
导致有时候Timer显示的数字会跳，不连续。
可能Timer还需要重写。